### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,18 @@
----
-# Documentation
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
--   package-ecosystem: github-actions
-    directory: /
-    schedule:
-        interval: semiannually
-
--   package-ecosystem: gitsubmodule
-    directory: /
-    schedule:
-        interval: semiannually
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: semiannually
+  groups:
+    actions-infrastructure:
+      patterns:
+      - actions/*
+- package-ecosystem: gitsubmodule
+  directory: /
+  schedule:
+    interval: semiannually
+  groups:
+    gitsubmodule-dependencies:
+      patterns:
+      - '*'


### PR DESCRIPTION
Adds a `groups` section to .github/dependabot.yml so dependabot PRs are grouped per ecosystem, matching the convention applied across other bids-apps/cpp-lln-lab/ohbm repos.